### PR TITLE
Fix to OnLoginPage()

### DIFF
--- a/WebWhatsappAPI/BaseClass.cs
+++ b/WebWhatsappAPI/BaseClass.cs
@@ -171,7 +171,7 @@ namespace WebWhatsappAPI
         {
             try
             {
-                if (driver.FindElement(By.XPath("//div[@class='qr-wrapper-container']")) != null)
+                if (driver.FindElement(By.XPath("//img[@alt='Scan me!']")) != null)
                 {
                     return true;
                 }


### PR DESCRIPTION
In the file `Whatsapp-Bot/WebWhatsappAPI/BaseClass.cs` at Line [174](https://github.com/IwraStudios/Whatsapp-Bot/blob/master/WebWhatsappAPI/BaseClass.cs#L174).
Change this `if(driver.FindElement(By.XPath("//div[@class='qr-wrapper-container']")) != null)`.
For this `if(driver.FindElement(By.XPath("//img[@alt='Scan me!']")) != null)`.

> This error is caused because the function is not finding the `qr-wrapper-container` element in the Login page, to solve you put an existing element in the Login page eg the QRCode itself.